### PR TITLE
xp --count option: only print the number of selected nodes.

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -2,7 +2,7 @@ name: code checks
 
 on:
   push:
-    branches: [ "main", "py3k" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v6
       with:
-        python-version: "3.9"
+        python-version: "3.10"
         cache: 'pip'
     - name: Install dependencies
       run: |
@@ -28,6 +28,9 @@ jobs:
     - name: Lint checks (Ruff)
       run: |
         ruff check --output-format=github
+    - name: Formatting checks (Ruff)
+      run: |
+        ruff format --diff
     - name: Import sort checks (isort)
       run: |
         isort --check --diff .

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,9 +6,10 @@ Changelog
 
 This document records all notable changes to `Xul <https://xul.readthedocs.io/>`_.
 
-`3.1.0-rc.1 <https://github.com/peteradrichem/Xul/compare/3.0.0...xp_count>`_ (2025-09-28)
-==========================================================================================
+`3.1.0 <https://github.com/peteradrichem/Xul/compare/3.0.0...3.1.0>`_ (2025-10-12)
+==================================================================================
 * Added ``--count`` option to :doc:`xp <xp>`: only print the number of selected nodes.
+* Last Python 3.9 release.
 
 `3.0.0 <https://github.com/peteradrichem/Xul/compare/2.5.1...3.0.0>`_ (2025-01-27)
 ==================================================================================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,14 +6,18 @@ Changelog
 
 This document records all notable changes to `Xul <https://xul.readthedocs.io/>`_.
 
+`3.1.0-rc.1 <https://github.com/peteradrichem/Xul/compare/3.0.0...xp_count>`_ (2025-09-28)
+==========================================================================================
+* Added ``--count`` option to :doc:`xp <xp>`: only print the number of selected nodes.
+
 `3.0.0 <https://github.com/peteradrichem/Xul/compare/2.5.1...3.0.0>`_ (2025-01-27)
 ==================================================================================
 * Drop support for Python < 3.9.
 * :doc:`xp <xp>`: fix boolean result (Python >= 3.12).
 * :doc:`xp <xp>`: fix string result representation (Python 3).
 * :doc:`xp <xp>`: improved printing of namespaces.
-* :doc:`transform <transform>`: syntax highlighting for terminal output
-* :doc:`transform <transform>`: added ``--no-syntax`` option for terminal output
+* :doc:`transform <transform>`: syntax highlighting for terminal output.
+* :doc:`transform <transform>`: added ``--no-syntax`` option for terminal output.
 * :doc:`transform <transform>`: removed ``--xsl-output`` option (always for ``--file``).
 * Fixed encoding issues.
 * Clearer error messages.

--- a/docs/ppx.rst
+++ b/docs/ppx.rst
@@ -18,13 +18,7 @@ Pretty print any local XML file:
 
    ppx file.xml
 
-Pretty print an RSS feed:
-
-.. code-block:: bash
-
-   ppx http://feeds.feedburner.com/PythonInsider
-
-Page an XML file with less:
+Page a syntax hightlighted XML file with less:
 
 .. code-block:: bash
 
@@ -35,6 +29,12 @@ Redirect output (pipe) to ``ppx``:
 .. code-block:: bash
 
    curl -s https://peps.python.org/peps.rss | ppx
+
+Pretty print an RSS feed:
+
+.. code-block:: bash
+
+   curl -s https://feeds.feedburner.com/PythonInsider | ppx
 
 Options
 =======

--- a/docs/xp.rst
+++ b/docs/xp.rst
@@ -42,7 +42,7 @@ Options
 
    $ xp --help
 
-   usage: xp [-h] [-V] [-l | -L] [-d DEFAULT_NS_PREFIX] [-e] [-q] [-p] [-r] [-m] xpath_expr [xml_source ...]
+   usage: xp [-h] [-V] [-l | -L] [-d DEFAULT_NS_PREFIX] [-e] [-q] [-c | -p] [-r] [-m] xpath_expr [xml_source ...]
 
    Select nodes in an XML source with an XPath expression.
 
@@ -72,6 +72,7 @@ Options
      -q, --quiet           don't print XML source namespaces
 
    element output options:
+     -c, --count           only print the number of selected nodes
      -p, --pretty-element  pretty print the result element
      -r, --result-xpath    print the XPath expression of the result element (or its parent)
 
@@ -159,15 +160,15 @@ List the five most recent Python Insider posts:
 
 .. code-block:: bash
 
-   xp "descendant::d:entry[position()<=5]/d:title/text()" \
-      http://feeds.feedburner.com/PythonInsider
+   curl -s https://feeds.feedburner.com/PythonInsider | \
+      xp "descendant::d:entry[position()<=5]/d:title/text()"
 
 You can change the prefix for the default namespace with the ``--default-prefix`` option:
 
 .. code-block:: bash
 
-   xp -d p "descendant::p:entry[position()<=5]/p:title/text()" \
-      http://feeds.feedburner.com/PythonInsider
+   curl -s https://feeds.feedburner.com/PythonInsider | \
+      xp -d p "descendant::p:entry[position()<=5]/p:title/text()" \
 
 
 .. index::
@@ -187,15 +188,15 @@ Find Python Insider posts published in or after 2015 with EXSLT (``date`` prefix
 
 .. code-block:: bash
 
-   xp -e "//d:entry[date:year(d:published) >= '2015']/d:title/text()" \
-      http://feeds.feedburner.com/PythonInsider
+   curl -s https://feeds.feedburner.com/PythonInsider | \
+      xp -e "//d:entry[date:year(d:published) >= '2015']/d:title/text()"
 
 Python Insider posts updated in December:
 
 .. code-block:: bash
 
-   xp -e "//d:entry[date:month-name(d:updated) = 'December']/d:title/text()" \
-      http://feeds.feedburner.com/PythonInsider
+   curl -s https://feeds.feedburner.com/PythonInsider | \
+      xp -e "//d:entry[date:month-name(d:updated) = 'December']/d:title/text()"
 
 
 .. index::
@@ -264,6 +265,24 @@ Pretty print the latest Python PEP:
 .. code-block:: bash
 
    curl -s https://peps.python.org/peps.rss | xp -p "//item[1]"
+
+
+.. index::
+   single: xp script; node count
+
+Node count
+----------
+.. program:: xp
+.. option:: -c, --count
+
+Only count the number of selected nodes with the ``--count`` command-line option.
+This is similar to ``grep --count`` using XPath instead of regular expressions.
+
+Count the number of series titles:
+
+.. code-block:: bash
+
+   xp --count "//d:Title[@type='parentSeriesTitle']" file1.xml file2.xml⋅file3.xml
 
 
 Other options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,15 @@ dynamic = [ "version" ]
 
 [project.optional-dependencies]
 docs = [
-    "furo==2024.8.6",
-    "Sphinx~=8.1.3"
+    "furo==2025.9.25",
+    "Sphinx~=8.2.3"
 ]
 test = [
-    "black~=24.10",
-    "isort~=5.13.2",
+    "black~=25.9",
+    "isort~=6.0.1",
     "lxml-stubs~=0.5.1",
-    "mypy~=1.14.1",
-    "ruff~=0.9.3",
+    "mypy~=1.18.2",
+    "ruff~=0.13.2",
     "types-Pygments~=2.19",
 ]
 syntax = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ authors = [
     { name = "Peter Adrichem", email = "Peter.Adrichem@gmail.com" }
 ]
 requires-python = ">=3.9"
-dependencies = [
-    "lxml>=4.0"
-]
+dependencies = [ "lxml>=4.0" ]
 keywords = [ "xml", "xpath", "xslt", "xsd", "dtd", "xml schema", "relax ng", "rng" ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -21,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Text Processing :: Markup :: XML",
     "Topic :: Utilities"
@@ -35,10 +34,10 @@ docs = [
 ]
 test = [
     "black~=25.9",
-    "isort~=6.0.1",
+    "isort~=6.1.0",
     "lxml-stubs~=0.5.1",
     "mypy~=1.18.2",
-    "ruff~=0.13.2",
+    "ruff~=0.14.0",
     "types-Pygments~=2.19",
 ]
 syntax = [
@@ -71,9 +70,7 @@ version = { attr = "xul.__version__" }
 where = ["src"]
 
 [tool.setuptools.package-data]
-xul = [
-    "py.typed"
-]
+xul = [ "py.typed" ]
 
 [tool.black]
 color = true
@@ -109,3 +106,8 @@ ignore = [
   "D213",       # Multi-line docstring summary should start at the second line
 ]
 pydocstyle.convention = "pep257"
+
+[tool.ruff.format]
+# Use `\n` line endings for all files
+line-ending = "lf"
+skip-magic-trailing-comma = true

--- a/src/xul/__init__.py
+++ b/src/xul/__init__.py
@@ -9,5 +9,5 @@ XML scripts in Python.
 """
 
 # Xul version.
-__version_info__ = ("3", "0", "0")
+__version_info__ = ("3", "1", "0")
 __version__ = ".".join(__version_info__)

--- a/src/xul/xsl.py
+++ b/src/xul/xsl.py
@@ -52,9 +52,7 @@ def build_xsl_transform(xslt_source: Union[TextIO, str]) -> Optional[etree.XSLT]
 
 
 def etree_transformer(
-    el_tree: etree._ElementTree,
-    transformer: etree.XSLT,
-    **params,
+    el_tree: etree._ElementTree, transformer: etree.XSLT, **params
 ) -> Optional[etree._XSLTResultTree]:
     """Transform an ElementTree with an XSL Transformer.
 

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,9 @@ echo() {
 echo "Lint checks (Ruff)"
 ruff check --output-format=concise
 
+echo "\nCheck formatting (Ruff)"
+ruff format --diff
+
 echo "\nCheck import sort (isort)"
 isort --check --diff .
 


### PR DESCRIPTION
`xp --count` option: only print the number of selected nodes.